### PR TITLE
Fixing engines problem with outdated dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,14 +20,14 @@
     "email": "ranm@codeoasis.com"
   },
   "dependencies": {
-    "newrelic": "~1",
-    "winston": "~0.7.2"
+    "newrelic": "^1",
+    "winston": ">=0.2 <2.4"
   },
   "devDependencies": {
-    "mocha": "~1.9.0",
-    "chai": "~1.6.1",
-    "sinon": "~1.7.2",
-    "rewire": "~1.1.3"
+    "chai": "^3.5",
+    "mocha": "^3.2",
+    "rewire": "^2.5",
+    "sinon": "^1.17"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixing problems of old dependencies requiring NodeJS 0.8 or something and using some deprecated APIs.

Dependencies are very "trusty" to allow to easier upgrades in other ones. Newrelic and others are doing semver properly.